### PR TITLE
random fixes

### DIFF
--- a/server/app/Controllers/Http/LanguageController.js
+++ b/server/app/Controllers/Http/LanguageController.js
@@ -1,12 +1,13 @@
 'use strict'
 
+const Language = use('App/Models/Language');
+
 class LanguageController {
   async index () {
-    const languages = await Language
+    return await Language
       .query()
       .withCount('snippets')
       .fetch()
-    return languages.toJSON()
   }
 }
 

--- a/server/app/Controllers/Http/SnippetController.js
+++ b/server/app/Controllers/Http/SnippetController.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const Snippet = use('App/Models/Snippet');
+
+class SnippetController {
+  async index () {
+    return await Snippet.all();
+  }
+}
+
+module.exports = SnippetController

--- a/server/app/Models/Language.js
+++ b/server/app/Models/Language.js
@@ -4,7 +4,7 @@ const Model = use('Model')
 
 class Language extends Model {
   snippets () {
-    return this.hasMany('App/Models/Snippet')
+    return this.hasMany('App/Models/Snippet', 'id', 'languageId')
   }
 }
 

--- a/server/app/Models/Snippet.js
+++ b/server/app/Models/Snippet.js
@@ -4,7 +4,7 @@ const Model = use('Model')
 
 class Snippet extends Model {
   language () {
-    return this.belongsTo('App/Models/Language')
+    return this.belongsTo('App/Models/Language', 'languageId', 'id')
   }
 }
 

--- a/server/database/migrations/1530548451243_snippet_schema.js
+++ b/server/database/migrations/1530548451243_snippet_schema.js
@@ -6,7 +6,7 @@ class SnippetSchema extends Schema {
   up () {
     this.create('snippets', (table) => {
       table.increments()
-      table.string('code', 255)
+      table.text('code')
       table.integer('languageId').unsigned().references('id').inTable('languages')
       table.timestamps()
     })

--- a/server/database/seeds/LanguageSeeder.js
+++ b/server/database/seeds/LanguageSeeder.js
@@ -11,12 +11,9 @@
 */
 
 const Factory = use('Factory')
-const Database = use('Database')
 
 class LanguageSeeder {
   async run () {
-    const languages = await Database.table('languages')
-    console.log(languages)
     Factory.model('App/Models/Language').createMany(5)
   }
 }

--- a/server/database/seeds/SnippetSeeder.js
+++ b/server/database/seeds/SnippetSeeder.js
@@ -11,13 +11,10 @@
 */
 
 const Factory = use('Factory')
-const Database = use('Database')
 const Snippet = use('App/Models/Snippet');
 
 class SnippetSeeder {
   async run () {
-    const snippets = await Database.table('snippets')
-    console.log(snippets)
     Factory.model('App/Models/Snippet').createMany(5)
   }
 }

--- a/server/start/routes.js
+++ b/server/start/routes.js
@@ -19,5 +19,6 @@ Route.group(() => {
   Route.post('auth/register', 'UserController.register')
   Route.post('auth/login', 'UserController.login')
   Route.get('languages', 'LanguageController.index')
+  Route.get('snippets', 'SnippetController.index')
 })
   .prefix('api/v1')


### PR DESCRIPTION
- you don't need to call languages.toJSON(); the controller by default will serialize into json
- in your models, adonis will assume ids are like "language_id", but since we are using "languageId", we need to manually specify the foreign / primary keys
- you should use text for the code since it will probably be over 255 characters
- added a snippets endpoint
- removing the Database.table calls which are crashing the seeder